### PR TITLE
Make MSBuildCommunityTasksLib path more robust and do not depend on MSBuild SolutionDir variable

### DIFF
--- a/BuildScripts/MSBuild.Community.Tasks.Targets
+++ b/BuildScripts/MSBuild.Community.Tasks.Targets
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="windows-1252" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
  <PropertyGroup>
    <MSBuildCommunityTasksPath Condition="'$(MSBuildCommunityTasksPath)' == ''">$(MSBuildProjectDirectory)\BuildScripts</MSBuildCommunityTasksPath>
    <MSBuildDnnBinPath Condition="'$(MSBuildDnnBinPath)' == ''">$(MSBuildProjectDirectory)\..\..\bin</MSBuildDnnBinPath>
-   <MSBuildCommunityTasksLib>$(SolutionDir)\packages\MSBuildTasks.1.4.0.88\tools\MSBuild.Community.Tasks.dll</MSBuildCommunityTasksLib>
+   <MSBuildCommunityTasksLib>$(MSBuildThisFileDirectory)\Solution\packages\MSBuildTasks.1.4.0.88\tools\MSBuild.Community.Tasks.dll</MSBuildCommunityTasksLib>
  </PropertyGroup>
  <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.AspNet.InstallAspNet" />
  <UsingTask AssemblyFile="$(MSBuildCommunityTasksLib)" TaskName="MSBuild.Community.Tasks.AssemblyInfo" />


### PR DESCRIPTION
This pull request fixes a problem that the MSBuildCommunityTasksLib variable depends on the MSBuild SolutionDir variable which was (for any reason) not correct in my development environment.