### PR TITLE
Added caching functionality for OpenContentController

### DIFF
--- a/Components/OpenContentController.cs
+++ b/Components/OpenContentController.cs
@@ -13,6 +13,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using DotNetNuke.Common.Utilities;
 using DotNetNuke.Data;
 using Newtonsoft.Json.Linq;
 using Satrabel.OpenContent.Components.Json;
@@ -24,10 +25,15 @@ namespace Satrabel.OpenContent.Components
 {
     public class OpenContentController
     {
+        private const string CachePrefix = "Satrabel.OpenContent.Components.OpenContentController-";
+        private const int CacheTime = 60;
+
         #region Commands
 
         public void AddContent(OpenContentInfo content, bool index, FieldConfig indexConfig)
         {
+            ClearCache(content);
+
             OpenContentVersion ver = new OpenContentVersion()
             {
                 Json = content.JsonAsJToken,
@@ -58,6 +64,8 @@ namespace Satrabel.OpenContent.Components
 
         public void DeleteContent(OpenContentInfo content, bool index)
         {
+            ClearCache(content);
+
             using (IDataContext ctx = DataContext.Instance())
             {
                 var rep = ctx.GetRepository<OpenContentInfo>();
@@ -72,6 +80,8 @@ namespace Satrabel.OpenContent.Components
 
         public void UpdateContent(OpenContentInfo content, bool index, FieldConfig indexConfig)
         {
+            ClearCache(content);
+
             OpenContentVersion ver = new OpenContentVersion()
             {
                 Json = content.JsonAsJToken,
@@ -123,38 +133,71 @@ namespace Satrabel.OpenContent.Components
 
         public IEnumerable<OpenContentInfo> GetContents(int moduleId)
         {
-            IEnumerable<OpenContentInfo> content;
+            var cacheArgs = new CacheItemArgs(GetModuleIdCacheKey(moduleId), CacheTime);
+            return DataCache.GetCachedData<IEnumerable<OpenContentInfo>>(cacheArgs, args => 
+                {
+                    IEnumerable<OpenContentInfo> content;
 
-            using (IDataContext ctx = DataContext.Instance())
-            {
-                var rep = ctx.GetRepository<OpenContentInfo>();
-                content = rep.Get(moduleId);
-            }
-            return content;
+                    using (IDataContext ctx = DataContext.Instance())
+                    {
+                        var rep = ctx.GetRepository<OpenContentInfo>();
+                        content = rep.Get(moduleId);
+                    }
+                    return content;
+                });
         }
 
         public OpenContentInfo GetContent(int contentId)
         {
-            OpenContentInfo content;
+            var cacheArgs = new CacheItemArgs(GetContentIdCacheKey(contentId), CacheTime);
+            return DataCache.GetCachedData<OpenContentInfo>(cacheArgs, args => 
+                {
+                    OpenContentInfo content;
 
-            using (IDataContext ctx = DataContext.Instance())
-            {
-                var rep = ctx.GetRepository<OpenContentInfo>();
-                content = rep.GetById(contentId);
-            }
-            return content;
+                    using (IDataContext ctx = DataContext.Instance())
+                    {
+                        var rep = ctx.GetRepository<OpenContentInfo>();
+                        content = rep.GetById(contentId);
+                    }
+                    return content;
+                });
         }
 
         public OpenContentInfo GetFirstContent(int moduleId)
         {
-            OpenContentInfo content;
+            var cacheArgs = new CacheItemArgs(GetModuleIdCacheKey(moduleId), CacheTime);
 
-            using (IDataContext ctx = DataContext.Instance())
-            {
-                var rep = ctx.GetRepository<OpenContentInfo>();
-                content = rep.Get(moduleId).FirstOrDefault();
-            }
-            return content;
+            return DataCache.GetCachedData<OpenContentInfo>(cacheArgs, args =>
+                {
+                    OpenContentInfo content;
+
+                    using (IDataContext ctx = DataContext.Instance())
+                    {
+                        var rep = ctx.GetRepository<OpenContentInfo>();
+                        content = rep.Get(moduleId).FirstOrDefault();
+                    }
+                    return content;
+                });
+        }
+
+        #endregion
+
+        #region Private helper
+
+        private static string GetContentIdCacheKey(int contentId)
+        {
+            return string.Concat(CachePrefix, "C-", contentId);
+        }
+
+        private static string GetModuleIdCacheKey(int moduleId)
+        {
+            return string.Concat(CachePrefix, "M-", moduleId);
+        }
+
+        private void ClearCache(OpenContentInfo content)
+        {
+            DataCache.ClearCache(GetContentIdCacheKey(content.ContentId));
+            DataCache.ClearCache(GetModuleIdCacheKey(content.ModuleId));
         }
 
         #endregion

--- a/Components/OpenContentController.cs
+++ b/Components/OpenContentController.cs
@@ -194,10 +194,10 @@ namespace Satrabel.OpenContent.Components
             return string.Concat(CachePrefix, "M-", moduleId);
         }
 
-        private void ClearCache(OpenContentInfo content)
+        private static void ClearCache(OpenContentInfo content)
         {
-            DataCache.ClearCache(GetContentIdCacheKey(content.ContentId));
-            DataCache.ClearCache(GetModuleIdCacheKey(content.ModuleId));
+            if (content.ContentId > 0) DataCache.ClearCache(GetContentIdCacheKey(content.ContentId));
+            if (content.ModuleId > 0) DataCache.ClearCache(GetModuleIdCacheKey(content.ModuleId));
         }
 
         #endregion

--- a/Components/OpenContentController.cs
+++ b/Components/OpenContentController.cs
@@ -133,7 +133,7 @@ namespace Satrabel.OpenContent.Components
 
         public IEnumerable<OpenContentInfo> GetContents(int moduleId)
         {
-            var cacheArgs = new CacheItemArgs(GetModuleIdCacheKey(moduleId), CacheTime);
+            var cacheArgs = new CacheItemArgs(GetModuleIdCacheKey(moduleId, "GetContents"), CacheTime);
             return DataCache.GetCachedData<IEnumerable<OpenContentInfo>>(cacheArgs, args => 
                 {
                     IEnumerable<OpenContentInfo> content;
@@ -165,8 +165,7 @@ namespace Satrabel.OpenContent.Components
 
         public OpenContentInfo GetFirstContent(int moduleId)
         {
-            var cacheArgs = new CacheItemArgs(GetModuleIdCacheKey(moduleId), CacheTime);
-
+            var cacheArgs = new CacheItemArgs(GetModuleIdCacheKey(moduleId) + "GetFirstContent", CacheTime);
             return DataCache.GetCachedData<OpenContentInfo>(cacheArgs, args =>
                 {
                     OpenContentInfo content;
@@ -189,9 +188,9 @@ namespace Satrabel.OpenContent.Components
             return string.Concat(CachePrefix, "C-", contentId);
         }
 
-        private static string GetModuleIdCacheKey(int moduleId)
+        private static string GetModuleIdCacheKey(int moduleId, string suffix = null)
         {
-            return string.Concat(CachePrefix, "M-", moduleId);
+            return string.Concat(CachePrefix, "M-", moduleId, string.IsNullOrEmpty(suffix) ? string.Empty : string.Concat("-", suffix));
         }
 
         private static void ClearCache(OpenContentInfo content)


### PR DESCRIPTION
Without caching, each OpenContent module uses one select query per page load (to get the data from the database). I've added some caching logic that stores the data in the DNN cache to avoid the select query. 