### PR TITLE
Added trailing slash to AppPath in AlpacaContext

### DIFF
--- a/Components/Alpaca/AlpacaContext.cs
+++ b/Components/Alpaca/AlpacaContext.cs
@@ -72,7 +72,7 @@ namespace Satrabel.OpenContent.Components.Alpaca
         {
             get
             {
-                return System.Web.VirtualPathUtility.ToAbsolute(System.Web.HttpRuntime.AppDomainAppVirtualPath);
+                return System.Web.VirtualPathUtility.ToAbsolute(string.Concat(System.Web.HttpRuntime.AppDomainAppVirtualPath, "/"));
             }
         }
     }


### PR DESCRIPTION
Follow-up pull request to #10 because System.Web.HttpRuntime.AppDomainAppVirtualPath return "OpenContent" in my environment and the path to the flags was set to localhost/opencontentimages (so a "/" was missing before images).