### PR TITLE
Support single template dnn search and add support for module terms support in dnn search

### DIFF
--- a/OpenContent/Components/FeatureController.cs
+++ b/OpenContent/Components/FeatureController.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using DotNetNuke.Common;
 using System;
 using DotNetNuke.Services.Search.Entities;
+using DotNetNuke.Entities.Content.Taxonomy;
 using Newtonsoft.Json.Linq;
 using DotNetNuke.Entities.Portals;
 using System.IO;
@@ -227,9 +228,35 @@ namespace Satrabel.OpenContent.Components
                 ModuleDefId = modInfo.ModuleDefID,
                 Url = url
             };
+            // Add support for module terms
+            if (modInfo.Terms != null && modInfo.Terms.Count > 0)
+            {
+                retval.Tags = CollectHierarchicalTags(modInfo.Terms);
+            }
+
 
             return retval;
         }
+
+        private static List<string> CollectHierarchicalTags(List<Term> terms)
+        {
+            Func<List<Term>, List<string>, List<string>> collectTagsFunc = null;
+            collectTagsFunc = (ts, tags) =>
+            {
+                if (ts != null && ts.Count > 0)
+                {
+                    foreach (var t in ts)
+                    {
+                        tags.Add(t.Name);
+                        tags.AddRange(collectTagsFunc(t.ChildTerms, new List<string>()));
+                    }
+                }
+                return tags;
+            };
+
+            return collectTagsFunc(terms, new List<string>());
+        }
+
 
         private static string JsonToSearchableString(JToken data)
         {

--- a/OpenContent/Components/FeatureController.cs
+++ b/OpenContent/Components/FeatureController.cs
@@ -141,11 +141,10 @@ namespace Satrabel.OpenContent.Components
                     if (DnnLanguageUtils.IsMultiLingualPortal(modInfo.PortalID))
                     {
                         searchDoc = GetLocalizedItem(modInfo, settings, content);
-                        searchDocuments.Add(searchDoc);
+                        searchDocuments.Add(searchDoc);                        
                         if (modInfo.LocalizedModules != null)
                             foreach (var localizedModule in modInfo.LocalizedModules)
-                            {
-                                Log.Logger.TraceFormat("Indexing content Module {0} - Tab {1} -  foreach (var localizedModule in modInfo.LocalizedModules)", modInfo.ModuleID, modInfo.TabID, modInfo.CultureCode);
+                            {                                
                                 SearchDocument localizedSearchDoc = GetLocalizedItem(localizedModule.Value, settings, content);
                                 searchDocuments.Add(localizedSearchDoc);
                             }
@@ -204,6 +203,15 @@ namespace Satrabel.OpenContent.Components
                 var hbEngine = new HandlebarsEngine();
                 docTitle = hbEngine.ExecuteWithoutFaillure(settings.Template.Main.DnnSearchTitle, dynForHBS, modInfo.ModuleTitle);
             }
+
+            // Check if it is a single template 
+            if (settings.Template?.Type != "multiple")
+            {
+                // With a signle template we don't want to identify the content by id.
+                url = TestableGlobals.Instance.NavigateURL(modInfo.TabID, ps, "");
+            } 
+
+
 
             var retval = new SearchDocument
             {

--- a/OpenContent/Components/FeatureController.cs
+++ b/OpenContent/Components/FeatureController.cs
@@ -116,8 +116,7 @@ namespace Satrabel.OpenContent.Components
             //    return searchDocuments;
             //}
             if (settings.IsOtherModule)
-            {
-                Log.Logger.TraceFormat("Indexing content Module {0} - Tab {1} - settings.IsOtherModule", modInfo.ModuleID, modInfo.TabID, modInfo.CultureCode);
+            {                
                 return searchDocuments;
             }
 
@@ -171,8 +170,7 @@ namespace Satrabel.OpenContent.Components
             JToken title;
             JToken description;
             JToken singleLanguage = content.Data.DeepClone(); //Clone to keep Simplification into this Method
-            JsonUtils.SimplifyJson(singleLanguage, culture);
-            Log.Logger.TraceFormat("Indexing content Module {0} - Tab {1} -  SearchDocument GetLocalizedItem", moduleInfo.ModuleID, moduleInfo.TabID, moduleInfo.CultureCode);
+            JsonUtils.SimplifyJson(singleLanguage, culture);            
             if (content.Title.IsJson())
             {
                 title = singleLanguage["Title"] ?? moduleInfo.ModuleTitle;
@@ -233,7 +231,6 @@ namespace Satrabel.OpenContent.Components
             {
                 retval.Tags = CollectHierarchicalTags(modInfo.Terms);
             }
-
 
             return retval;
         }

--- a/OpenContent/Components/FeatureController.cs
+++ b/OpenContent/Components/FeatureController.cs
@@ -109,12 +109,14 @@ namespace Satrabel.OpenContent.Components
 
             var module = new OpenContentModuleInfo(modInfo);
             OpenContentSettings settings = modInfo.OpenContentSettings();
-            if (settings.Template?.Main == null || !settings.Template.Main.DnnSearch)
-            {
-                return searchDocuments;
-            }
+            //if (settings.Template?.Main == null || !settings.Template.Main.DnnSearch)
+            //{
+            //    Log.Logger.TraceFormat("Indexing content Module {0} - Tab {1} - settings.Template?.Main == null || !settings.Template.Main.DnnSearch", modInfo.ModuleID, modInfo.TabID, modInfo.CultureCode);
+            //    return searchDocuments;
+            //}
             if (settings.IsOtherModule)
             {
+                Log.Logger.TraceFormat("Indexing content Module {0} - Tab {1} - settings.IsOtherModule", modInfo.ModuleID, modInfo.TabID, modInfo.CultureCode);
                 return searchDocuments;
             }
 
@@ -143,6 +145,7 @@ namespace Satrabel.OpenContent.Components
                         if (modInfo.LocalizedModules != null)
                             foreach (var localizedModule in modInfo.LocalizedModules)
                             {
+                                Log.Logger.TraceFormat("Indexing content Module {0} - Tab {1} -  foreach (var localizedModule in modInfo.LocalizedModules)", modInfo.ModuleID, modInfo.TabID, modInfo.CultureCode);
                                 SearchDocument localizedSearchDoc = GetLocalizedItem(localizedModule.Value, settings, content);
                                 searchDocuments.Add(localizedSearchDoc);
                             }
@@ -169,7 +172,7 @@ namespace Satrabel.OpenContent.Components
             JToken description;
             JToken singleLanguage = content.Data.DeepClone(); //Clone to keep Simplification into this Method
             JsonUtils.SimplifyJson(singleLanguage, culture);
-
+            Log.Logger.TraceFormat("Indexing content Module {0} - Tab {1} -  SearchDocument GetLocalizedItem", moduleInfo.ModuleID, moduleInfo.TabID, moduleInfo.CultureCode);
             if (content.Title.IsJson())
             {
                 title = singleLanguage["Title"] ?? moduleInfo.ModuleTitle;


### PR DESCRIPTION
I've add support for module terms in the dnn search. Based on the way it works in the html module.

I've added support for single template based dnn search. I've you don't want you're module indexed by the dnn search than you can use the normal dnn way to disable indexing the module.

I've fixed so that the id is not included in the single template.

![single page template dnn search](https://user-images.githubusercontent.com/72070/27068870-747f8220-5012-11e7-9726-eaa793a35d76.png)
