### PR TITLE
Hotfix/enhanced edit permissions

### DIFF
--- a/OpenContent/Components/OpenContentAPIController.cs
+++ b/OpenContent/Components/OpenContentAPIController.cs
@@ -1,9 +1,9 @@
 #region Copyright
 
-// 
+//
 // Copyright (c) 2015-2017
 // by Satrabel
-// 
+//
 
 #endregion
 
@@ -845,7 +845,7 @@ namespace Satrabel.OpenContent.Components
                 }
                 return Request.CreateResponse(HttpStatusCode.OK, new
                 {
-                    isValid = true                 
+                    isValid = true
                 });
             }
             catch (Exception exc)
@@ -867,7 +867,7 @@ namespace Satrabel.OpenContent.Components
         /// Gets or sets the value field.
         /// </summary>
         /// <value>
-        /// The Id field. 
+        /// The Id field.
         /// </value>
         public string valueField { get; set; }
         /// <summary>
@@ -884,14 +884,14 @@ namespace Satrabel.OpenContent.Components
         /// Gets or sets the data key.
         /// </summary>
         /// <value>
-        /// Which additional data object to search. 
+        /// Which additional data object to search.
         /// </value>
         public string dataKey { get; set; }
         /// <summary>
         /// Gets or sets the data member.
         /// </summary>
         /// <value>
-        /// Optional The data member of the data object to search. 
+        /// Optional The data member of the data object to search.
         /// </value>
         public string dataMember { get; set; }
         /// <summary>

--- a/OpenContent/Components/OpenContentAPIController.cs
+++ b/OpenContent/Components/OpenContentAPIController.cs
@@ -364,11 +364,6 @@ namespace Satrabel.OpenContent.Components
                 var dataItems = ds.GetData(dsContext, additionalDataManifest.ScopeType, additionalDataManifest.StorageKey ?? key);
                 if (dataItems != null)
                 {
-                    if (!OpenContentUtils.HasEditPermissions(PortalSettings, module.ViewModule, module.Settings.Manifest.GetEditRole(), dataItems))
-                    {
-                        return Request.CreateResponse(HttpStatusCode.Unauthorized);
-                    }
-
                     JToken json = dataItems.Data;
                     if (!string.IsNullOrEmpty(req.dataMember))
                     {

--- a/OpenContent/Components/OpenContentAPIController.cs
+++ b/OpenContent/Components/OpenContentAPIController.cs
@@ -337,7 +337,7 @@ namespace Satrabel.OpenContent.Components
         /// <param name="req">The req.</param>
         /// <returns></returns>
         [ValidateAntiForgeryToken]
-        [DnnModuleAuthorize(AccessLevel = SecurityAccessLevel.Edit)]
+        [DnnModuleAuthorize(AccessLevel = SecurityAccessLevel.View)]
         [HttpPost]
         public HttpResponseMessage LookupData(LookupDataRequestDTO req)
         {
@@ -355,6 +355,11 @@ namespace Satrabel.OpenContent.Components
                 var dataItems = ds.GetData(dsContext, additionalDataManifest.ScopeType, additionalDataManifest.StorageKey ?? key);
                 if (dataItems != null)
                 {
+                    if (!OpenContentUtils.HasEditPermissions(PortalSettings, module.ViewModule, module.Settings.Manifest.GetEditRole(), dataItems))
+                    {
+                        return Request.CreateResponse(HttpStatusCode.Unauthorized);
+                    }
+
                     JToken json = dataItems.Data;
                     if (!string.IsNullOrEmpty(req.dataMember))
                     {
@@ -379,7 +384,7 @@ namespace Satrabel.OpenContent.Components
         }
 
         [ValidateAntiForgeryToken]
-        [DnnModuleAuthorize(AccessLevel = SecurityAccessLevel.Edit)]
+        [DnnModuleAuthorize(AccessLevel = SecurityAccessLevel.View)]
         [HttpPost]
         public HttpResponseMessage Lookup(LookupRequestDTO req)
         {
@@ -397,7 +402,8 @@ namespace Satrabel.OpenContent.Components
                     var items = ds.GetAll(dsContext, null).Items;
                     if (items != null)
                     {
-                        foreach (var item in items)
+                        var itemUserHasPermissionToEdit = items.Where(item => OpenContentUtils.HasEditPermissions(PortalSettings, module.ViewModule, module.Settings.Manifest.GetEditRole(), item));
+                        foreach (var item in itemUserHasPermissionToEdit)
                         {
                             var json = item.Data;
 
@@ -435,6 +441,11 @@ namespace Satrabel.OpenContent.Components
                     var struc = ds.Get(dsContext, null);
                     if (struc != null)
                     {
+                        if (!OpenContentUtils.HasEditPermissions(PortalSettings, module.ViewModule, module.Settings.Manifest.GetEditRole(), struc))
+                        {
+                            return Request.CreateResponse(HttpStatusCode.Unauthorized);
+                        }
+
                         JToken json = struc.Data;
                         if (!string.IsNullOrEmpty(req.dataMember))
                         {
@@ -463,7 +474,7 @@ namespace Satrabel.OpenContent.Components
         }
 
         [ValidateAntiForgeryToken]
-        [DnnModuleAuthorize(AccessLevel = SecurityAccessLevel.Edit)]
+        [DnnModuleAuthorize(AccessLevel = SecurityAccessLevel.View)]
         [HttpPost]
         public HttpResponseMessage LookupCollection(LookupCollectionRequestDTO req)
         {
@@ -481,7 +492,8 @@ namespace Satrabel.OpenContent.Components
                     var items = ds.GetAll(dsContext, null).Items;
                     if (items != null)
                     {
-                        foreach (var item in items)
+                        var itemUserHasPermissionToEdit = items.Where(item => OpenContentUtils.HasEditPermissions(PortalSettings, module.ViewModule, module.Settings.Manifest.GetEditRole(), item));
+                        foreach (var item in itemUserHasPermissionToEdit)
                         {
                             var json = item.Data as JObject;
                             if (json?[req.textField] != null)

--- a/OpenContent/Components/OpenContentAPIController.cs
+++ b/OpenContent/Components/OpenContentAPIController.cs
@@ -54,6 +54,11 @@ namespace Satrabel.OpenContent.Components
             try
             {
                 var moduleInfo = new OpenContentModuleInfo(ActiveModule);
+                if (moduleInfo.Settings.Manifest.DisableEdit)
+                {
+                    return Request.CreateResponse(HttpStatusCode.Unauthorized);
+                }
+
                 IDataSource ds = DataSourceManager.GetDataSource(moduleInfo.Settings.Manifest.DataSource);
                 var dsContext = OpenContentUtils.CreateDataContext(moduleInfo);
                 IDataItem dsItem = null;
@@ -148,8 +153,12 @@ namespace Satrabel.OpenContent.Components
             try
             {
                 var module = new OpenContentModuleInfo(ActiveModule);
-                var dataManifest = module.Settings.Manifest.GetAdditionalData(key);
+                if (module.Settings.Manifest.DisableEdit)
+                {
+                    return Request.CreateResponse(HttpStatusCode.Unauthorized);
+                }
 
+                var dataManifest = module.Settings.Manifest.GetAdditionalData(key);
                 IDataSource ds = DataSourceManager.GetDataSource(module.Settings.Manifest.DataSource);
                 var dsContext = OpenContentUtils.CreateDataContext(module, UserInfo.UserID);
 

--- a/OpenContent/Components/Rest/RestController.cs
+++ b/OpenContent/Components/Rest/RestController.cs
@@ -389,7 +389,7 @@ namespace Satrabel.OpenContent.Components.Rest
                 res[entity] = items;
                 return Request.CreateResponse(HttpStatusCode.OK, res);
 
-                //return Request.CreateResponse(HttpStatusCode.OK, ""); 
+                //return Request.CreateResponse(HttpStatusCode.OK, "");
             }
             catch (Exception exc)
             {

--- a/OpenContent/Components/Utils/OpenContentUtils.cs
+++ b/OpenContent/Components/Utils/OpenContentUtils.cs
@@ -590,7 +590,7 @@ namespace Satrabel.OpenContent.Components
             }
             if (permissions)
             {
-                // Roles                
+                // Roles
                 string fieldName = "";
                 if (IndexConfig?.Fields != null && IndexConfig.Fields.ContainsKey("userrole"))
                 {

--- a/OpenContent/Components/Utils/OpenContentUtils.cs
+++ b/OpenContent/Components/Utils/OpenContentUtils.cs
@@ -501,6 +501,11 @@ namespace Satrabel.OpenContent.Components
             return FolderUri.ReverseMapPath(path);
         }
 
+        public static bool HasEditPermissions(PortalSettings portalSettings, ModuleInfo module, string editrole, IDataItem dataItem)
+        {
+            return HasEditPermissions(portalSettings, module, editrole, dataItem.CreatedByUserId);
+        }
+
         public static bool HasEditPermissions(PortalSettings portalSettings, ModuleInfo module, string editrole, int createdByUserId)
         {
             return module.HasEditRightsOnModule() || HasEditRole(portalSettings, editrole, createdByUserId);
@@ -512,6 +517,7 @@ namespace Satrabel.OpenContent.Components
             if (portalSettings.UserInfo.IsInRole(editrole) && (createdByUserId == -1 || createdByUserId == portalSettings.UserId)) return true;
             return false;
         }
+
         public static FieldConfig GetIndexConfig(TemplateManifest template)
         {
             return GetIndexConfig(template.Key.TemplateDir, template.Collection);

--- a/OpenContent/Edit.ascx.cs
+++ b/OpenContent/Edit.ascx.cs
@@ -14,6 +14,9 @@ using DotNetNuke.Entities.Modules;
 using DotNetNuke.Common;
 using Satrabel.OpenContent.Components;
 using Satrabel.OpenContent.Components.Alpaca;
+using Satrabel.OpenContent.Components.Manifest;
+using Satrabel.OpenContent.Components.Datasource;
+using DotNetNuke.Common.Utilities;
 
 #endregion
 
@@ -24,6 +27,13 @@ namespace Satrabel.OpenContent
         protected override void OnInit(EventArgs e)
         {
             base.OnInit(e);
+
+            if (!CanEditOrAddContent())
+            {
+                // If the user is not authorized to add/edit this content redirect them back to the default view control.
+                this.Response.Redirect(Globals.NavigateURL(this.TabId));
+            }
+
             var bootstrap = OpenContentControllerFactory.Instance.OpenContentGlobalSettingsController.GetEditLayout() != AlpacaLayoutEnum.DNN;
             bool loadBootstrap = bootstrap && OpenContentControllerFactory.Instance.OpenContentGlobalSettingsController.GetLoadBootstrap();
             hlCancel.NavigateUrl = Globals.NavigateURL();
@@ -38,7 +48,42 @@ namespace Satrabel.OpenContent
             AlpacaContext.Horizontal = OpenContentControllerFactory.Instance.OpenContentGlobalSettingsController.GetEditLayout() == AlpacaLayoutEnum.BootstrapHorizontal;
             AlpacaContext.IsNew = settings.Template.IsListTemplate && string.IsNullOrEmpty(itemId);
         }
+
         public AlpacaContext AlpacaContext { get; private set; }
+
+        /// <summary>Determines whether the current user is authorized to edit this content.</summary>
+        /// <returns><c>true</c> if this current user is authroized to edit this content; otherwise, <c>false</c>.</returns>
+        private bool CanEditOrAddContent()
+        {
+            var id = this.Request.QueryString["id"];
+            var moduleInfo = new OpenContentModuleInfo(this.ModuleConfiguration);
+            var createdByUserid = string.IsNullOrEmpty(id) ? Null.NullInteger : GetCreatedByUserIdForEditContent(moduleInfo, id);
+            return !moduleInfo.Settings.Manifest.DisableEdit
+                && OpenContentUtils.HasEditPermissions(PortalSettings, moduleInfo.ViewModule, moduleInfo.Settings.Manifest.GetEditRole(), createdByUserid);
+        }
+
+        /// <summary>Gets the created by user ID for the content.</summary>
+        /// <param name="moduleInfo">The module information.</param>
+        /// <param name="id">The content ID.</param>
+        /// <returns>The created by user ID or -1 if the content was not found.</returns>
+        private int GetCreatedByUserIdForEditContent(OpenContentModuleInfo moduleInfo, string id)
+        {
+            var ds = DataSourceManager.GetDataSource(moduleInfo.Settings.Manifest.DataSource);
+            var dsContext = OpenContentUtils.CreateDataContext(moduleInfo);
+            IDataItem dsItem = null;
+
+            if (moduleInfo.IsListMode() && !string.IsNullOrEmpty(id))
+            {
+                dsItem = ds.Get(dsContext, id);
+            }
+            else
+            {
+                dsContext.Single = true;
+                dsItem = ds.Get(dsContext, null);
+            }
+
+            return dsItem?.CreatedByUserId ?? Null.NullInteger;
+        }
     }
 }
 

--- a/OpenContent/Edit.ascx.cs
+++ b/OpenContent/Edit.ascx.cs
@@ -1,9 +1,9 @@
 #region Copyright
 
-// 
+//
 // Copyright (c) 2015-2016
 // by Satrabel
-// 
+//
 
 #endregion
 


### PR DESCRIPTION
Enhancements
- Removed white space
- Added layer of security to prevent the edit control from being displayed if the current user does not have edit rights
- Added layer of security to prevent the edit control from being displayed if manifest has disabled edit functionality
- Updated the API methods for Edit to return a 401 unauthorized if the manifest has editing disabled.
- Updated the API methods for lookups to have DNN View permission and perform a permissions check based on the content the user is trying to access. 