### PR TITLE
Hotfix/enhance string searching

### DIFF
--- a/OpenContent/Components/Datasource/search/OperatorEnum.cs
+++ b/OpenContent/Components/Datasource/search/OperatorEnum.cs
@@ -6,6 +6,8 @@
         NOT_EQUAL,
         BETWEEN,
         START_WITH,
+        ENDS_WITH,
+        CONTAINS,
         LESS_THEN,
         GREATER_THEN,
         LESS_THEN_OR_EQUALS,

--- a/OpenContent/Components/Lucene/Config/SelectQueryDefinition.cs
+++ b/OpenContent/Components/Lucene/Config/SelectQueryDefinition.cs
@@ -5,6 +5,7 @@ using Lucene.Net.Search;
 using Lucene.Net.Index;
 using Satrabel.OpenContent.Components.Datasource.Search;
 using Lucene.Net.QueryParsers;
+using Satrabel.OpenContent.Components.Lucene.Mapping;
 
 namespace Satrabel.OpenContent.Components.Lucene.Config
 {
@@ -64,8 +65,8 @@ namespace Satrabel.OpenContent.Components.Lucene.Config
             foreach (var rule in filterRules)
             {
                 string fieldName = rule.Field;
-                if (fieldName == "id") fieldName = "$id";
-                if (fieldName == "userid") fieldName = "$userid";
+                if (fieldName == "id") fieldName = JsonMappingUtils.FieldId;
+                if (fieldName == "userid") fieldName = JsonMappingUtils.FieldUserId;
 
                 if (rule.FieldOperator == OperatorEnum.EQUAL)
                 {
@@ -81,7 +82,8 @@ namespace Satrabel.OpenContent.Components.Lucene.Config
                     }
                     else if (rule.FieldType == FieldTypeEnum.STRING || rule.FieldType == FieldTypeEnum.TEXT || rule.FieldType == FieldTypeEnum.HTML)
                     {
-                        q.Add(LuceneController.ParseQuery(this.ApplyAsteriskToSearchQuery(rule.Value.AsString, prepend: true, append: true), fieldName), cond);
+                        var performStringContainsSearch = !fieldName.Equals(JsonMappingUtils.FieldId) && !fieldName.Equals(JsonMappingUtils.FieldUserId);
+                        q.Add(LuceneController.ParseQuery(this.ApplyAsteriskToSearchQuery(rule.Value.AsString, prepend: performStringContainsSearch, append: performStringContainsSearch), fieldName), cond);
                     }
                     else
                     {

--- a/OpenContent/Components/Lucene/Config/SelectQueryDefinition.cs
+++ b/OpenContent/Components/Lucene/Config/SelectQueryDefinition.cs
@@ -81,7 +81,7 @@ namespace Satrabel.OpenContent.Components.Lucene.Config
                     }
                     else if (rule.FieldType == FieldTypeEnum.STRING || rule.FieldType == FieldTypeEnum.TEXT || rule.FieldType == FieldTypeEnum.HTML)
                     {
-                        q.Add(LuceneController.ParseQuery(rule.Value.AsString + "*", fieldName), cond);
+                        q.Add(LuceneController.ParseQuery(this.ApplyAsteriskToSearchQuery(rule.Value.AsString, prepend: true, append: true), fieldName), cond);
                     }
                     else
                     {

--- a/OpenContent/Components/Lucene/Config/SelectQueryDefinition.cs
+++ b/OpenContent/Components/Lucene/Config/SelectQueryDefinition.cs
@@ -87,7 +87,7 @@ namespace Satrabel.OpenContent.Components.Lucene.Config
                     }
                     else
                     {
-                        string searchstring = QueryParser.Escape(rule.Value.AsString);                        
+                        string searchstring = QueryParser.Escape(rule.Value.AsString);
                         q.Add(new TermQuery(new Term(fieldName, searchstring)), cond);
                     }
                 }
@@ -112,11 +112,11 @@ namespace Satrabel.OpenContent.Components.Lucene.Config
                     BooleanQuery arrQ = new BooleanQuery();
                     foreach (var arrItem in rule.MultiValue)
                     {
-                        arrQ.Add(new TermQuery(new Term(fieldName, QueryParser.Escape(arrItem.AsString))), Occur.SHOULD); // OR                        
+                        arrQ.Add(new TermQuery(new Term(fieldName, QueryParser.Escape(arrItem.AsString))), Occur.SHOULD); // OR
                         /*
                         var phraseQ = new PhraseQuery();
                         phraseQ.Add(new Term(fieldName, arrItem.AsString));
-                        arrQ.Add(phraseQ, Occur.SHOULD); // OR                        
+                        arrQ.Add(phraseQ, Occur.SHOULD); // OR
                          */
                     }
                     q.Add(arrQ, cond);

--- a/OpenContent/Components/Lucene/Config/SelectQueryDefinition.cs
+++ b/OpenContent/Components/Lucene/Config/SelectQueryDefinition.cs
@@ -97,11 +97,33 @@ namespace Satrabel.OpenContent.Components.Lucene.Config
                 {
                     if (rule.FieldType == FieldTypeEnum.STRING || rule.FieldType == FieldTypeEnum.TEXT || rule.FieldType == FieldTypeEnum.HTML)
                     {
-                        q.Add(LuceneController.ParseQuery(rule.Value.AsString + "*", fieldName), cond);
+                        q.Add(LuceneController.ParseQuery(this.ApplyAsteriskToSearchQuery(rule.Value.AsString, prepend: false, append: true), fieldName), cond);
                     }
                     else
                     {
-                        q.Add(new WildcardQuery(new Term(fieldName, rule.Value.AsString + "*")), cond);
+                        q.Add(new WildcardQuery(new Term(this.ApplyAsteriskToSearchQuery(rule.Value.AsString, prepend: false, append: true))), cond);
+                    }
+                }
+                else if (rule.FieldOperator == OperatorEnum.ENDS_WITH)
+                {
+                    if (rule.FieldType == FieldTypeEnum.STRING || rule.FieldType == FieldTypeEnum.TEXT || rule.FieldType == FieldTypeEnum.HTML)
+                    {
+                        q.Add(LuceneController.ParseQuery(this.ApplyAsteriskToSearchQuery(rule.Value.AsString, prepend: true, append: false), fieldName), cond);
+                    }
+                    else
+                    {
+                        q.Add(new WildcardQuery(new Term(fieldName, this.ApplyAsteriskToSearchQuery(rule.Value.AsString, prepend: true, append: false))), cond);
+                    }
+                }
+                else if (rule.FieldOperator == OperatorEnum.CONTAINS)
+                {
+                    if (rule.FieldType == FieldTypeEnum.STRING || rule.FieldType == FieldTypeEnum.TEXT || rule.FieldType == FieldTypeEnum.HTML)
+                    {
+                        q.Add(LuceneController.ParseQuery(this.ApplyAsteriskToSearchQuery(rule.Value.AsString, prepend: true, append: true), fieldName), cond);
+                    }
+                    else
+                    {
+                        q.Add(new WildcardQuery(new Term(fieldName, this.ApplyAsteriskToSearchQuery(rule.Value.AsString, prepend: true, append: true))), cond);
                     }
                 }
                 else if (rule.FieldOperator == OperatorEnum.IN)
@@ -208,6 +230,29 @@ namespace Satrabel.OpenContent.Components.Lucene.Config
                 sortfieldtype = SortField.STRING;
                 sortFieldPrefix = "@";
             }
+        }
+
+        private string ApplyAsteriskToSearchQuery(string searchQuery, bool prepend, bool append)
+        {
+            if (prepend
+                && !searchQuery.StartsWith("\"", StringComparison.InvariantCultureIgnoreCase)
+                && !searchQuery.StartsWith("?", StringComparison.InvariantCultureIgnoreCase)
+                && !searchQuery.StartsWith(" ", StringComparison.InvariantCultureIgnoreCase)
+                && !searchQuery.StartsWith("*", StringComparison.InvariantCultureIgnoreCase))
+            {
+                searchQuery = $"*{searchQuery}";
+            }
+
+            if (append
+                && !searchQuery.EndsWith("\"", StringComparison.InvariantCultureIgnoreCase)
+                && !searchQuery.EndsWith("?", StringComparison.InvariantCultureIgnoreCase)
+                && !searchQuery.EndsWith(" ", StringComparison.InvariantCultureIgnoreCase)
+                && !searchQuery.EndsWith("*", StringComparison.InvariantCultureIgnoreCase))
+            {
+                searchQuery = $"{searchQuery}*";
+            }
+
+            return searchQuery;
         }
     }
 }

--- a/OpenContent/Components/Lucene/LuceneController.cs
+++ b/OpenContent/Components/Lucene/LuceneController.cs
@@ -231,6 +231,7 @@ namespace Satrabel.OpenContent.Components.Lucene
         public static Query ParseQuery(string searchQuery, string defaultFieldName)
         {
             var parser = new QueryParser(Version.LUCENE_30, defaultFieldName, JsonMappingUtils.GetAnalyser());
+            parser.AllowLeadingWildcard = true;
             Query query;
             try
             {

--- a/OpenContent/Components/Lucene/LuceneController.cs
+++ b/OpenContent/Components/Lucene/LuceneController.cs
@@ -91,7 +91,7 @@ namespace Satrabel.OpenContent.Components.Lucene
         #region Index
 
         /// <summary>
-        /// Use this to 
+        /// Use this to
         /// </summary>
         /// <param name="list">The list.</param>
         /// <param name="indexConfig">The index configuration.</param>
@@ -177,7 +177,7 @@ namespace Satrabel.OpenContent.Components.Lucene
             if (settings.IsOtherModule)
             {
                 moduleId = settings.ModuleId;
-            }            
+            }
             lc.Store.Delete(new TermQuery(new Term("$type", OpenContentInfo.GetScope(moduleId, settings.Template.Collection))));
             OpenContentController occ = new OpenContentController();
             foreach (var item in occ.GetContents(moduleId, settings.Template.Collection))


### PR DESCRIPTION
- Cleanup whitespace
- Add ability to have search queries start with a * to support contains operations.
- Correct spelling of AddRulles to AddRules and make building queries from FilterGroups work recursively.
- Add support for ENDS_WITH and CONTAINS for query operations of strings.
- Update the EQUALS query operations for strings for behave like contains instead of starts with.