### PR TITLE
Update ReleaseNotes.txt to point at Github

### DIFF
--- a/OpenContent/ReleaseNotes.txt
+++ b/OpenContent/ReleaseNotes.txt
@@ -1,5 +1,4 @@
 ﻿<h3>OpenContent</h3>
 <p class="Contributor">
-	<a href="https://opencontent.codeplex.com/releases">opencontent.codeplex.com</a><br />
+	<a href="https://github.com/sachatrauwaen/OpenContent/releases">github.com/sachatrauwaen/OpenContent/releases</a>
 </p>
-


### PR DESCRIPTION
The old link went to the releases page on Codeplex, so I've pointed this one at the Github releases page.