### PR TITLE
Implemented dnnSearchUrl template option

### DIFF
--- a/OpenContent/Components/FeatureController.cs
+++ b/OpenContent/Components/FeatureController.cs
@@ -235,6 +235,14 @@ namespace Satrabel.OpenContent.Components
                 // With a signle template we don't want to identify the content by id.
                 url = TestableGlobals.Instance.NavigateURL(modInfo.TabID, ps, "");
             }
+            // chek if we have a dnnSearchUrl field
+            // if we have, we use the OpenContent url as default
+            if (!string.IsNullOrEmpty(settings.Template?.Main?.DnnSearchUrl))
+            {
+                var dicForHbs = JsonUtils.JsonToDictionary(contentData.ToString());
+                var hbEngine = new HandlebarsEngine();
+                url = hbEngine.ExecuteWithoutFaillure(settings.Template.Main.DnnSearchUrl, dicForHbs, url);
+            }
 
             // instanciate the search document
             var retval = new SearchDocument

--- a/OpenContent/Components/Manifest/TemplateFiles.cs
+++ b/OpenContent/Components/Manifest/TemplateFiles.cs
@@ -63,6 +63,15 @@ namespace Satrabel.OpenContent.Components.Manifest
         [JsonProperty(PropertyName = "dnnSearchText")]
         public string DnnSearchText { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value specifying the url to use for the indexed document in [DNN search].
+        /// </summary>
+        /// <value>
+        ///   You can use a Handlebars template.
+        /// </value>
+        [JsonProperty(PropertyName = "dnnSearchUrl")]
+        public string DnnSearchUrl { get; set; }
+
         [JsonProperty(PropertyName = "model")]
         public Dictionary<string, CollectionManifest> Model { get; set; }
     }


### PR DESCRIPTION
This PR implements a new template field dnnSearchUrl.

It's a HBS-templatable field to be used for the Url-field in de search document. Can be used to set the URL for a search document to another URL than the OpenContent  item URL.

For example: If an Open Content item is just used to add content to the search results on a website,, but links to another site, this can be used to make the search result link directly to the target site.