### PR TITLE
Fixes #178, EPPPlus.dll missing in manifest 

### DIFF
--- a/OpenContent/OpenContent.dnn
+++ b/OpenContent/OpenContent.dnn
@@ -293,6 +293,10 @@
               <name>Handlebars.dll</name>
               <path>bin</path>
             </assembly>
+            <assembly>
+              <name>EPPlus.dll</name>
+              <path>bin</path>
+            </assembly>
           </assemblies>
         </component>
       </components>


### PR DESCRIPTION
Because of this, the dll is not copied to the Bin folder