### PR TITLE
Fix: Ignore .github folder when listing templates from GitHub repositories

### DIFF
--- a/OpenContent/Components/Github/GithubTemplateUtils.cs
+++ b/OpenContent/Components/Github/GithubTemplateUtils.cs
@@ -60,8 +60,14 @@ namespace Satrabel.OpenContent.Components
                 var response = client.GetStringAsync(new Uri(url)).Result;
                 if (response != null)
                 {
+                    // Parse the response and add the contents
+                    var allContents = Contents.FromJson(response);
+
+                    // Filter the .github folder
+                    var filteredContents = allContents.Where(content => !content.Name.Equals(".github", StringComparison.OrdinalIgnoreCase)).ToList();
+
                     //content = JArray.Parse(response);
-                    contents .AddRange(Contents.FromJson(response));
+                    contents.AddRange(filteredContents);
                 }
             }
             return contents;


### PR DESCRIPTION
## Related to Issue
Fixes #280 

## Description
This PR fixes an issue where the `.github` folder was being listed as a template when fetching templates from GitHub repositories. The `.github` folder is now filtered out and excluded from the list of templates.

The change was made in the `GetTemplateList` method in `GithubTemplateUtils.cs`. A filter was added to exclude any folder named `.github` from the list of contents returned by the GitHub API.

## How Has This Been Tested?
- Verified that the `.github` folder is no longer listed as a template when fetching templates from GitHub repositories.
- Ensured that other templates are listed correctly.
- Tested in a local development environment with multiple repositories containing `.github` folders.

## Screenshots (if appropriate):
#### Before
![Before Fix]![image](https://github.com/user-attachments/assets/5b1167e4-95bf-46d2-9be6-6b301f1b6f46)

#### After
![image](https://github.com/user-attachments/assets/f1221abe-0cd0-4de0-a5ee-0307816324fe)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.